### PR TITLE
added delete functionality for gateway and robot from LNS and Database

### DIFF
--- a/src/views/master-admin/gateways/GatewayDeletion.js
+++ b/src/views/master-admin/gateways/GatewayDeletion.js
@@ -1,0 +1,56 @@
+import axios from "axios";
+import toast from "react-hot-toast";
+
+// ✅ Delete Gateway from LNS server
+export const deleteGatewayFromLns = async (gateway_id, authtoken, reason) => {
+  if (!reason || reason.trim() === "") {
+    toast.error("Reason is required.");
+    return;
+  }
+
+  try {
+    const res = await axios.delete(
+      `/api/v1/gateways/delete-lns/${gateway_id}`,
+      {
+        headers: { Authorization: `Bearer ${authtoken}` },
+        data: { reason },
+      }
+    );
+
+    toast.success(
+      res.data.message || `Gateway ${gateway_id} deleted from LNS.`
+    );
+  } catch (error) {
+    toast.error(error.response?.data?.message || "Error deleting from LNS.");
+  }
+};
+
+// ✅ Delete Gateway from Database
+export const deleteGatewayFromDatabase = async (
+  gateway_id,
+  authtoken,
+  reason
+) => {
+  if (!reason || reason.trim() === "") {
+    toast.error("Reason is required.");
+    return;
+  }
+
+  try {
+    const res = await axios.delete(
+      `/api/v1/gateways/delete/${gateway_id}`, // ✅ corrected endpoint
+      {
+        headers: { Authorization: `Bearer ${authtoken}` },
+        data: { reason },
+      }
+    );
+
+    toast.success(
+      res.data.message || `Gateway ${gateway_id} deleted from Database.`
+    );
+  } catch (error) {
+    toast.error(
+      error.response?.data?.message || "Error deleting from Database."
+    );
+  }
+};

--- a/src/views/master-admin/gateways/Gateways.js
+++ b/src/views/master-admin/gateways/Gateways.js
@@ -15,6 +15,9 @@ import {
   CInputGroup,
   CFormInput,
   CBadge,
+  CModalFooter,
+  CButton,
+  CFormLabel,
 } from "@coreui/react";
 import { Link } from "react-router-dom";
 import LoadingSpinner from "../../../components/LoadingSpinner";
@@ -25,6 +28,10 @@ import PaginateInput from "../../../components/PaginateInput";
 import LastActivity from "../../../components/LastActivity";
 import CIcon from "@coreui/icons-react";
 import { cilX } from "@coreui/icons";
+import {
+  deleteGatewayFromDatabase,
+  deleteGatewayFromLns,
+} from "./GatewayDeletion";
 
 const reducer = (state, action) => {
   switch (action.type) {
@@ -93,6 +100,12 @@ const Gateways = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [loading, setLoading] = useState(false);
   const [modalOpendloading, setModalOpendloadingg] = useState(false);
+  // Add these states with your other state declarations
+  const [showGatewayDeleteModal, setShowGatewayDeleteModal] = useState(false);
+  const [gatewayDeleteType, setGatewayDeleteType] = useState(""); // 'lns' or 'db'
+  const [gatewayDeleteReason, setGatewayDeleteReason] = useState("");
+  const [isGatewayDeleting, setIsGatewayDeleting] = useState(false);
+
   const userInfo = useSelector((state) => state.userInfo);
   let adminroute = "";
 
@@ -227,7 +240,6 @@ const Gateways = () => {
           Add
         </Link>
       </div>
-
       <CRow className="justify-content-end">
         <CCol xs={12} sm={10} md={8} lg={5}>
           <CInputGroup className="mb-3">
@@ -302,12 +314,14 @@ const Gateways = () => {
                       <CBadge color="danger">Offline</CBadge>
                     )}
                   </CTableDataCell>
-                  <CTableDataCell style={{ minWidth: "180px" }}>
+                  <CTableDataCell style={{ minWidth: "380px" }}>
+                    {" "}
+                    {/* Increased min-width to accommodate more buttons */}
                     <Link
                       className="btn btn-sm btn-info text-decoration-none p-1 m-1"
                       onClick={() => openModal(gateway)}
                     >
-                      View Details
+                      View
                     </Link>
                     <Link
                       className="btn btn-sm btn-success text-decoration-none p-1 m-1"
@@ -317,10 +331,31 @@ const Gateways = () => {
                     </Link>
                     <Link
                       to={`/${adminroute}/all-site-gateways/update-gateway/${gateway._id}`}
-                      className="btn btn-secondary p-1  text-decoration-none  btn-sm  m-1"
+                      className="btn btn-secondary p-1 text-decoration-none btn-sm m-1"
                     >
                       Update
                     </Link>
+                    {/* Add delete buttons */}
+                    <button
+                      className="btn btn-sm btn-danger p-1 m-1"
+                      onClick={() => {
+                        setSelectedGateway(gateway);
+                        setGatewayDeleteType("lns");
+                        setShowGatewayDeleteModal(true);
+                      }}
+                    >
+                      Del from LNS
+                    </button>
+                    <button
+                      className="btn btn-sm btn-outline-warning p-1 m-1"
+                      onClick={() => {
+                        setSelectedGateway(gateway);
+                        setGatewayDeleteType("db");
+                        setShowGatewayDeleteModal(true);
+                      }}
+                    >
+                      Del from DB
+                    </button>
                   </CTableDataCell>
                 </CTableRow>
               ))
@@ -519,6 +554,113 @@ const Gateways = () => {
             </CModalBody>
           </>
         )}
+      </CModal>
+      {/* delete gateway */}
+
+      <CModal
+        size="md"
+        visible={showGatewayDeleteModal}
+        onClose={() => !isGatewayDeleting && setShowGatewayDeleteModal(false)}
+        backdrop="static"
+      >
+        <CModalHeader closeButton={false}>
+          <CModalTitle>
+            Delete Gateway - {selectedGateway?.gateway_id}
+          </CModalTitle>
+          <button
+            type="button"
+            className="border-0 ms-auto py-0 px-1"
+            onClick={() =>
+              !isGatewayDeleting && setShowGatewayDeleteModal(false)
+            }
+            style={{ background: "none" }}
+            disabled={isGatewayDeleting}
+          >
+            <CIcon icon={cilX} size="lg" />
+          </button>
+        </CModalHeader>
+
+        <CModalBody>
+          {isGatewayDeleting ? (
+            <div className="text-center">
+              <LoadingSpinner />
+              <p>Deleting gateway, please wait...</p>
+            </div>
+          ) : (
+            <>
+              <p>
+                Are you sure you want to delete this gateway from{" "}
+                <strong>
+                  {gatewayDeleteType === "lns" ? "LNS" : "Database"}
+                </strong>
+                ?
+              </p>
+              <CFormLabel>Reason for Deletion</CFormLabel>
+              <CFormInput
+                type="text"
+                placeholder="Enter reason..."
+                value={gatewayDeleteReason}
+                onChange={(e) => setGatewayDeleteReason(e.target.value)}
+                disabled={isGatewayDeleting}
+              />
+            </>
+          )}
+        </CModalBody>
+
+        <CModalFooter>
+          <CButton
+            color="secondary"
+            size="sm"
+            onClick={() => {
+              setShowGatewayDeleteModal(false);
+              setGatewayDeleteReason("");
+            }}
+            disabled={isGatewayDeleting}
+          >
+            Cancel
+          </CButton>
+
+          <CButton
+            color="danger"
+            size="sm"
+            onClick={async () => {
+              if (!gatewayDeleteReason.trim()) {
+                toast.error("Reason is required.");
+                return;
+              }
+
+              setIsGatewayDeleting(true);
+              try {
+                if (gatewayDeleteType === "lns") {
+                  await deleteGatewayFromLns(
+                    selectedGateway.gateway_id,
+                    authtoken,
+                    gatewayDeleteReason
+                  );
+                } else {
+                  await deleteGatewayFromDatabase(
+                    selectedGateway.gateway_id,
+                    authtoken,
+                    gatewayDeleteReason
+                  );
+                }
+              } catch (error) {
+                toast.error("Delete operation failed");
+              } finally {
+                setIsGatewayDeleting(false);
+                setShowGatewayDeleteModal(false);
+                setGatewayDeleteReason("");
+              }
+            }}
+            disabled={isGatewayDeleting}
+          >
+            {isGatewayDeleting ? (
+              <LoadingSpinner size="sm" />
+            ) : (
+              "Confirm Delete"
+            )}
+          </CButton>
+        </CModalFooter>
       </CModal>
     </div>
   );

--- a/src/views/master-admin/robots/DeleteRobots.js
+++ b/src/views/master-admin/robots/DeleteRobots.js
@@ -1,0 +1,43 @@
+import axios from "axios";
+import toast from "react-hot-toast";
+
+// 🔹 Delete from LNS server
+export const deleteRobotFromLns = async (
+  robot_no,
+  deveui,
+  authtoken,
+  reason
+) => {
+  try {
+    const res = await axios.delete(`/api/v1/robots/delete-lns/${deveui}`, {
+      headers: { Authorization: `Bearer ${authtoken}` },
+      data: { reason, robot_no },
+    });
+
+    toast.success(res.data.message || `Robot ${robot_no} deleted from LNS.`);
+    return true;
+  } catch (error) {
+    toast.error(error.response?.data?.message || "Error deleting from LNS.");
+    return false;
+  }
+};
+
+// 🔹 Delete from Database
+export const deleteRobotFromDatabase = async (robot_no, authtoken, reason) => {
+  try {
+    const res = await axios.delete(`/api/v1/robots/delete/${robot_no}`, {
+      headers: { Authorization: `Bearer ${authtoken}` },
+      data: { reason },
+    });
+
+    toast.success(
+      res.data.message || `Robot ${robot_no} deleted from Database.`
+    );
+    return true;
+  } catch (error) {
+    toast.error(
+      error.response?.data?.message || "Error deleting from Database."
+    );
+    return false;
+  }
+};

--- a/src/views/master-admin/robots/RobotLogDetials.js
+++ b/src/views/master-admin/robots/RobotLogDetials.js
@@ -385,6 +385,19 @@ const RobotLogDetails = () => {
           </CCardHeader>
           <CCardBody>
             <CRow className="mb-3">
+              <CCol className="d-flex justify-content-end">
+                <CButton
+                  color="primary"
+                  className="btn-sm"
+                  onClick={exportEntirePayloadToExcel}
+                  disabled={loading}
+                >
+                  Export
+                </CButton>
+              </CCol>
+            </CRow>
+
+            <CRow className="mb-3">
               <CCol md={2}>
                 <CFormSelect
                   label="Chart Type"
@@ -414,37 +427,26 @@ const RobotLogDetails = () => {
                 </CFormSelect>
               </CCol>
 
-              <CCol md={3}>
+              <CCol md={2}>
                 <CFormLabel>Start Date</CFormLabel>
                 <CFormInput
                   type="date"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
                   disabled={loading}
+                  style={{ width: "100%" }}
                 />
               </CCol>
 
-              <CCol md={3}>
+              <CCol md={2}>
                 <CFormLabel>End Date</CFormLabel>
                 <CFormInput
                   type="date"
                   value={endDate}
                   onChange={(e) => setEndDate(e.target.value)}
                   disabled={loading}
+                  style={{ width: "100%" }}
                 />
-              </CCol>
-            </CRow>
-
-            <CRow className="mb-3">
-              <CCol md={2} className="d-flex align-items-end">
-                <CButton
-                  color="primary"
-                  className="btn-sm"
-                  onClick={exportEntirePayloadToExcel}
-                  disabled={loading}
-                >
-                  Export All Data
-                </CButton>
               </CCol>
             </CRow>
 

--- a/src/views/master-admin/robots/Robots.js
+++ b/src/views/master-admin/robots/Robots.js
@@ -14,6 +14,9 @@ import {
   CModalTitle,
   CModalBody,
   CBadge,
+  CButton,
+  CModalFooter,
+  CFormLabel,
 } from "@coreui/react";
 import { Link } from "react-router-dom";
 import toast from "react-hot-toast";
@@ -22,6 +25,9 @@ import { useSelector } from "react-redux";
 import LoadingSpinner from "../../../components/LoadingSpinner";
 import LastActivity from "../../../components/LastActivity";
 import PaginateInput from "../../../components/PaginateInput";
+import { deleteRobotFromDatabase, deleteRobotFromLns } from "./DeleteRobots";
+import { cilX } from "@coreui/icons";
+import CIcon from "@coreui/icons-react";
 const reducer = (state, action) => {
   switch (action.type) {
     case "FETCH_SITES_REQUEST":
@@ -67,12 +73,16 @@ const Robots = () => {
 
   const [searchTerm, setSearchTerm] = useState("");
   const [modalVisible, setModalVisible] = useState(false);
-  const [selectedRobot, setSelectedRobot] = useState(null);
 
   const [pageInput, setPageInput] = useState("");
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteType, setDeleteType] = useState(""); // 'lns' or 'db'
+  const [selectedRobot, setSelectedRobot] = useState(null);
+  const [deleteReason, setDeleteReason] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const [formData, setFormData] = useState({
     robot_no: "",
@@ -242,8 +252,8 @@ const Robots = () => {
               Block
             </CTableHeaderCell>
             <CTableHeaderCell>Site ID</CTableHeaderCell>
-            <CTableHeaderCell style={{ minWidth: "180px" }}>
-              Action
+            <CTableHeaderCell style={{ minWidth: "340px" }}>
+              Actions
             </CTableHeaderCell>
           </CTableRow>
         </CTableHead>
@@ -308,20 +318,37 @@ const Robots = () => {
                 <CTableDataCell>
                   <Link
                     className="btn btn-sm btn-secondary m-1"
-                    color="secondary"
-                    size="sm"
                     to={`/${adminroute}/robots/${robot._id}`}
-                    // onClick={() => openModal(robot)}
                   >
                     View
                   </Link>
-
                   <Link
                     className="btn btn-sm btn-warning m-1"
                     to={`/master-admin/robots/update/${robot._id}`}
                   >
                     Update
                   </Link>
+                  <button
+                    className="btn btn-sm btn-danger m-1"
+                    onClick={() => {
+                      setSelectedRobot(robot);
+                      setDeleteType("lns");
+                      setShowDeleteModal(true);
+                    }}
+                  >
+                    Del from LNS
+                  </button>
+
+                  <button
+                    className="btn btn-sm btn-outline-warning m-1"
+                    onClick={() => {
+                      setSelectedRobot(robot);
+                      setDeleteType("db");
+                      setShowDeleteModal(true);
+                    }}
+                  >
+                    Del from DB
+                  </button>
                 </CTableDataCell>
               </CTableRow>
             ))
@@ -334,6 +361,93 @@ const Robots = () => {
           )}
         </CTableBody>
       </CTable>
+
+      {/* delete Modal */}
+      <CModal
+        size="md"
+        visible={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        backdrop="static"
+      >
+        <CModalHeader closeButton={false}>
+          <CModalTitle>Delete Robot - {selectedRobot?.robot_no}</CModalTitle>
+          <button
+            type="button"
+            className="border-0 ms-auto py-0 px-1"
+            onClick={() => {
+              setShowDeleteModal(false);
+              setDeleteReason("");
+            }}
+            style={{ background: "none" }}
+          >
+            <CIcon icon={cilX} size="lg" />
+          </button>
+        </CModalHeader>
+
+        <CModalBody>
+          <p>
+            Are you sure you want to delete this robot from{" "}
+            <strong>{deleteType === "lns" ? "LNS" : "Database"}</strong>?
+          </p>
+
+          <CFormLabel>Reason for Deletion</CFormLabel>
+          <CFormInput
+            type="text"
+            placeholder="Enter reason..."
+            value={deleteReason}
+            onChange={(e) => setDeleteReason(e.target.value)}
+          />
+        </CModalBody>
+
+        <CModalFooter>
+          <CButton
+            color="secondary"
+            size="sm"
+            onClick={() => {
+              setShowDeleteModal(false);
+              setDeleteReason("");
+            }}
+          >
+            Cancel
+          </CButton>
+
+          <CButton
+            color="danger"
+            size="sm"
+            onClick={async () => {
+              if (!deleteReason.trim()) {
+                toast.error("Reason is required.");
+                return;
+              }
+
+              setIsDeleting(true);
+
+              try {
+                if (deleteType === "lns") {
+                  await deleteRobotFromLns(
+                    selectedRobot.robot_no,
+                    selectedRobot.deveui,
+                    authtoken,
+                    deleteReason
+                  );
+                } else {
+                  await deleteRobotFromDatabase(
+                    selectedRobot.robot_no,
+                    authtoken,
+                    deleteReason
+                  );
+                }
+              } finally {
+                setIsDeleting(false);
+                setShowDeleteModal(false);
+                setDeleteReason("");
+              }
+            }}
+          >
+            {isDeleting ? <LoadingSpinner size="sm" /> : "Confirm Delete"}
+          </CButton>
+        </CModalFooter>
+      </CModal>
 
       <PaginateInput
         page={page}

--- a/src/views/site-technician/dpr/SiteTechnicianAddDpr.js
+++ b/src/views/site-technician/dpr/SiteTechnicianAddDpr.js
@@ -179,13 +179,10 @@ const SiteTechnicianAddDpr = () => {
     } catch (error) {
       dispatch({
         type: "SUBMIT_FAIL",
-        payload:
-          error.response?.data?.error || "Error Adding Daily Progress Report",
+        payload: error.response?.data?.error || error.response?.data?.message,
       });
 
-      toast.error(
-        error.response.data.error || "Error Adding Daily Progress Report"
-      );
+      toast.error(error.response?.data?.error || error.response?.data?.message);
     }
   };
 


### PR DESCRIPTION
- Implemented reusable confirmation modal for deleting gateways and robots
- Added 'Delete from LNS' and 'Delete from DB' buttons for both gateways and robots
- Created frontend utility functions for delete operations with reason input
- Integrated API calls for LNS and DB deletion with toast notifications
- Ensured validation and proper modal state handling